### PR TITLE
Resize should accept only a width or only a height

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -25,13 +25,21 @@ module.exports = function (proto) {
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-resize
   proto.resize = function resize (w, h, options) {
     options = options || "";
+		var geometry;
+		if (w && h) {
+			geometry = w + "x" + h + options
+		} else if (w && !h) {
+			geometry = w + options
+	  } else if (!w && h) {
+      geometry = 'x' + h + options
+		}
 
     // avoid error "geometry does not contain image (unable to crop image)" - gh-17
     if (!(this.inputIs('jpg') && ~this._out.indexOf('-crop'))) {
-      this.in("-size",  w +"x"+ h + options);
+      this.in("-size",  geometry);
     }
 
-    return this.out("-resize", w +"x"+ h + options);
+    return this.out("-resize", geometry);
   }
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-scale


### PR DESCRIPTION
In GraphicsMagic, when using resize, we can pass only a width or only a height. From their documentation:

If only the width is specified, the width assumes the value and the height is chosen to maintain the aspect ratio of the image. Similarly, if only the height is specified (e.g., -geometry x256), the width is chosen to maintain the aspect ratio.

I modified the code to accept only a width or only a height on a resize. I've tested manually but could not figure out how to run your test suite so I did not add a test for it. 'make test' was failing for me before I made my change.
