### PR TITLE
Fix crash when attempting to parse a stdout line with no key, e.g. "  :?"

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -110,6 +110,9 @@ module.exports = function (gm) {
             o = out.root = out.indent[level] = self.data;
           } else if (indent < level) {
             // outdent
+            if (!(indent in out.indent)) {
+              continue;
+            }
             o = out.indent[indent];
           } else if (indent > level) {
             // dropping into a nested object


### PR DESCRIPTION
An image seems to mess up the stdout parsing of **gm**. The offending line is `:??`.

[Here's a copy of the image and test](http://dropbox.com/sh/5g0qpwc2d6nzbyz/oZD4MJZvRE/gm_crash_test.zip), and here's a snippet from the trace:

```
TypeError: Cannot set property '' of undefined

  Identify stdout:
  Image: /Users/chris/img.jpg
  Format: JPEG (Joint Photographic Experts Group JFIF format)
...
  0x00000000: 1800                                          -
    unknown:
  :??
  Profile-EXIF: 11310 bytes
    Make: Canon
    Model: Canon EOS 1000D
...
  Tainted: False
  User Time: 0.010u
  Elapsed Time: 0:01
  Pixels Per Second: 30.5M
    at ChildProcess.<anonymous> (/Users/chris/node_modules/gm/lib/getters.js:124:20)
    at ChildProcess.<anonymous> (/Users/chris/node_modules/gm/lib/command.js:207:18)
    at ChildProcess.emit (events.js:70:17)
    at maybeExit (child_process.js:360:16)
    at Process.onexit (child_process.js:396:5)
```
