### PR TITLE
When in imageMagick mode, complain about missing imageMagick

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -216,7 +216,13 @@ module.exports = function (proto) {
 
       proc.on(cpEndEvent, onExit = function (code, signal) {
         if (code !== 0 || signal !== null) {
-          if (127 == code) stderr += '** Have you installed graphicsmagick? **\n';
+          if (127 == code) {
+            if (self._options.imageMagick) {
+              stderr += '** Have you installed imageMagick? **\n';
+            } else {
+              stderr += '** Have you installed graphicsmagick? **\n';
+            }
+          }
           err = new Error('Command failed: ' + stderr);
           err.code = code;
           err.signal = signal;


### PR DESCRIPTION
This is a really simple cosmetic change that causes gm to ask "Have you installed imageMagick?" instead of "have you installed graphicsmagick?" when you get an error in imageMagick mode.  Doing it this way will save developers time debugging their team's apps that use gm for imagemagick, not for graphicsmagick.
