### PR TITLE
Add support for thumbnail

### DIFF
--- a/examples/thumbnail.js
+++ b/examples/thumbnail.js
@@ -1,0 +1,10 @@
+var gm = require('../')
+  , dir = __dirname + '/imgs'
+  
+gm(dir + '/original.jpg')
+  .thumbnail(150, 150)
+  .write(dir + '/thumbnail.jpg', function(err){
+    if (err) return console.dir(arguments)
+    console.log(this.outname + " created  ::  " + arguments[3])
+  }
+) 

--- a/lib/args.js
+++ b/lib/args.js
@@ -564,6 +564,11 @@ module.exports = function (proto) {
     return this.out("-threshold", value+(percent?'%':''));
   }
 
+  // http://www.graphicsmagick.org/GraphicsMagick.html#details-thumbnail
+  proto.thumbnail = function thumbnail (width, height) {
+    return this.out("-thumbnail", width + "x" + height);
+  }
+
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-tile
   proto.tile = function tile (filename) {
     return this.out("-tile", filename);

--- a/test/thumbnail.js
+++ b/test/thumbnail.js
@@ -1,0 +1,9 @@
+
+module.exports = function (gm, dir, finish) {
+
+  gm
+  .thumbnail(200, 200)
+  .write(dir + '/thumbnail.png', function thumbnail (err) {
+    finish(err);
+  });
+}


### PR DESCRIPTION
Currently the helper `.thumb` first performs a `.size`, computes crop dimensions, and then crops and resizes the image.

I want to generate thumbnails but tried to avoid this two-pass method. I bumped into a [superuser question](http://superuser.com/questions/275476/square-thumbnails-with-imagemagick-convert) which uses the `-thumbnail` option, but this is not available in gm.

This pull requests extends args with support for thumbnail, includes a simple test, and an example. I reckon thumbnail might conflict with thumb in a naming sense, but its the official name.
