### PR TITLE
[minor] now getters.js prints the error out instead of throwing, which c...

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -76,6 +76,8 @@ module.exports = function (gm) {
         return callback.call(self, err, stdout, stderr, cmd);
       }
 
+      var error = null;
+
       stdout = (stdout||"").trim().replace(/\r\n|\r/g, "\n");
 
       var parts = stdout.split("\n");
@@ -136,14 +138,14 @@ module.exports = function (gm) {
         }
 
       } catch (err) {
-        err.message = err.message + "\n\n  Identify stdout:\n  " + stdout
-        console.log('Something went wrong while executing your gm commmand! Look! \n' + err.message);
+        err.message = err.message + "\n\n  Identify stdout:\n  " + stdout;
+        error = err;
       }
 
       var idx = self._iq.length;
 
       while (idx--) {
-        self._iq[idx].call(self, null, self.data);
+        self._iq[idx].call(self, error, self.data);
       }
 
       self._identifying = false;


### PR DESCRIPTION
...an kill the process entirely since context is lost. This is bad for my use case, in which many images are coming through the server as part of other docs, and we need the process to finish in order to have the docs continue through the entire pipeline. This may not be good for other use cases, so I understand if there is no merge.
