### PR TITLE
added; handle Buffer as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ gm(readStream, 'img.jpg')
 
 ````
 
+## Buffer as source
+```` js
+var gm  = require('../')
+  , fs  = require('fs')
+
+var buf = fs.readFileSync(__dirname + '/image.jpg');
+
+gm(buf)
+.noise('laplacian')
+.write(__dirname + '/out.jpg', function (err) {
+  if (err) {
+    throw err;
+  }
+
+  console.log('Created image from buffer!');
+});
+
+````
+
 ## Getting started
 First download and install [GraphicsMagick](http://www.graphicsmagick.org/)
 

--- a/examples/source_buffer.js
+++ b/examples/source_buffer.js
@@ -1,0 +1,13 @@
+var gm  = require('../')
+  , fs  = require('fs')
+  , dir = __dirname + '/../examples/imgs'
+
+var buf = fs.readFileSync(dir + '/original.jpg');
+
+gm(buf)
+.noise('laplacian')
+.write(dir + '/fromBuffer.png', function (err) {
+  if (err) return console.dir(arguments);
+
+  console.log(this.outname + ' created :: ' + arguments[3]);
+});

--- a/index.js
+++ b/index.js
@@ -48,20 +48,26 @@ function gm (source, height, color) {
     }
   }
 
-  // parse out gif frame brackets from filename
-  // since stream doesn't use source path
-  // eg. "filename.gif[0]"
-  var frames = source.match(/(\[.+\])$/);
-  if (frames) {
-    this.sourceFrames = source.substr(frames.index, frames[0].length);
-    source = source.substr(0, frames.index);
+  if (typeof source === "string") {
+    // then source is a path
+    
+    // parse out gif frame brackets from filename
+    // since stream doesn't use source path
+    // eg. "filename.gif[0]"
+    var frames = source.match(/(\[.+\])$/);
+    if (frames) {
+      this.sourceFrames = source.substr(frames.index, frames[0].length);
+      source = source.substr(0, frames.index);
+    }
   }
 
   this.source = source;
 
   this.addSrcFormatter(function (src) {
     // must be first source formatter
-    var ret = this.sourceStream ? '-' : this.source;
+    var inputFromStdin = this.sourceStream || Buffer.isBuffer(this.source);
+
+    var ret = inputFromStdin ? '-' : this.source;
     if (ret && this.sourceFrames) ret += this.sourceFrames;
     src.length = 0;
     src[0] = ret;

--- a/lib/command.js
+++ b/lib/command.js
@@ -184,6 +184,11 @@ module.exports = function (proto) {
 
     debug(cmd);
 
+    if (Buffer.isBuffer(this.source)) {
+      proc.stdin.write(this.source);
+      proc.stdin.end();
+    }
+
     // pipe in the sourceStream if present
     if (self.sourceStream) {
 


### PR DESCRIPTION
Picking up from #19, #92.

Added support for `Buffer` as source. No extra methods, see `examples/fromBuffer.js` for an example. Unfortunately, due to the ugly setup for testing, I could not write a good test case for this, but I'm open to suggestions.

Let me know if the changes are ok, and I'll push docs.
