### PR TITLE
args: Different geometry formatting for GM

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -681,7 +681,8 @@ module.exports = function (proto) {
     if (w && h) {
       geometry = w + "x" + h + options
     } else if (w && !h) {
-      geometry = w + options
+      // GraphicsMagick requires <width>x<options>, ImageMagick requires <width><options>
+      geometry = (this._options.imageMagick) ? w + options : w + 'x' + options;
     } else if (!w && h) {
       geometry = 'x' + h + options
     }
@@ -696,7 +697,7 @@ module.exports = function (proto) {
     if (w && h) {
       geometry = w + "x" + h + options
     } else if (w && !h) {
-      geometry = w + options
+      geometry = (this._options.imageMagick) ? w + options : w + 'x' + options;
     } else if (!w && h) {
       geometry = 'x' + h + options
     }
@@ -999,7 +1000,7 @@ module.exports = function (proto) {
     if (w && h) {
       geometry = w + "x" + h + options
     } else if (w && !h) {
-      geometry = w + options
+      geometry = (this._options.imageMagick) ? w + options : w + 'x' + options;
     } else if (!w && h) {
       geometry = 'x' + h + options
     }

--- a/test/118.js
+++ b/test/118.js
@@ -1,0 +1,25 @@
+/*
+ * If only the width is specified for a resize operation, 
+ * GraphicsMagick requires the format
+ * -resize 10x
+ * while ImageMagick requires the format
+ * -resize 10 
+ *
+ */
+var assert = require('assert')
+
+module.exports = function (_, dir, finish, gm) {
+  if (!gm.integration)  return finish();
+    
+  var src = dir + '/originalSideways.jpg';
+  var dst = dir + '/originalSideways10x.jpg';
+
+  gm(src).resize(10).write(dst, function(err) {
+    gm(dst).size(function(err, size) {
+      if (err) return finish(err);
+      assert.equal(10, size.width);
+      finish();
+    });
+  });
+
+}

--- a/test/resize.js
+++ b/test/resize.js
@@ -7,7 +7,11 @@ module.exports = function (gm, dir, finish, GM) {
   var args = a.args();
   assert.equal('convert', args[0]);
   assert.equal('-resize', args[2]);
-  assert.equal('10', args[3]);
+  if (a._options.imageMagick) {
+    assert.equal('10', args[3]);
+  } else {
+    assert.equal('10x', args[3]);
+  }
 
   var a = GM('img.png').resize(10, 20);
   var args = a.args();
@@ -19,13 +23,21 @@ module.exports = function (gm, dir, finish, GM) {
   var args = a.args();
   assert.equal('convert', args[0]);
   assert.equal('-resize', args[2]);
-  assert.equal('10%', args[3]);
+  if (a._options.imageMagick) {
+    assert.equal('10%', args[3]);
+  } else {
+    assert.equal('10x%', args[3]);
+  }
 
   var a = GM('img.png').resize('10%');
   var args = a.args();
   assert.equal('convert', args[0]);
   assert.equal('-resize', args[2]);
-  assert.equal('10%', args[3]);
+  if (a._options.imageMagick) {
+    assert.equal('10%', args[3]);
+  } else {
+    assert.equal('10%x', args[3]);
+  }
 
   var m = gm
   .resize(58, 50, '%');

--- a/test/resizeAndAutoOrientFromBuffer.js
+++ b/test/resizeAndAutoOrientFromBuffer.js
@@ -16,7 +16,11 @@ module.exports = function (_, dir, finish, gm) {
   assert.equal('convert', args[0]);
   assert.equal('-', args[1]);
   assert.equal('-resize', args[2]);
-  assert.equal('20%', args[3]);
+  if (m._options.imageMagick) {
+    assert.equal('20%', args[3]);
+  } else {
+    assert.equal('20%x', args[3]);
+  }
 
   if (!gm.integration)
     return finish();

--- a/test/resizeBuffer.js
+++ b/test/resizeBuffer.js
@@ -15,7 +15,11 @@ module.exports = function (_, dir, finish, gm) {
   assert.equal('convert', args[0]);
   assert.equal('-', args[1]);
   assert.equal('-resize', args[2]);
-  assert.equal('48%', args[3]);
+  if (m._options.imageMagick) {
+    assert.equal('48%', args[3]);
+  } else {
+    assert.equal('48%x', args[3]);
+  }
 
   if (!gm.integration)
     return finish();

--- a/test/scale.js
+++ b/test/scale.js
@@ -7,7 +7,11 @@ module.exports = function (gm, dir, finish, GM) {
   var args = a.args();
   assert.equal('convert', args[0]);
   assert.equal('-scale', args[2]);
-  assert.equal('100', args[3]);
+  if (a._options.imageMagick) {
+    assert.equal('100', args[3]);
+  } else {
+    assert.equal('100x', args[3]);
+  }
 
   var a = GM('img.png').scale(100, 200, '%');
   var args = a.args();


### PR DESCRIPTION
If only the width is specified for a resize operation,
GraphicsMagick requires the format `-resize 10x`
while ImageMagick requires the format `-resize 10`
