### PR TITLE
Prevent process crash when identifying files does not exist.

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -244,6 +244,9 @@ module.exports = function (proto) {
         stderr += data;
       });
 
+      // Prevent process crash
+      proc.on('error', function(error) { });
+
       proc.on('close', onExit = function (code, signal) {
         if (code !== 0 || signal !== null) {
           if (127 == code)


### PR DESCRIPTION
Process crashes when executing:

``` javascript
gm('/file_not_exists').identify(function(error) {
  console.log(arguments);
});
```
