### PR TITLE
Fixed an issue where resize would not scale up an image if only given width

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -688,8 +688,13 @@ module.exports = function (proto) {
     if (w && h) {
       geometry = w + "x" + h + options
     } else if (w && !h) {
-      // GraphicsMagick requires <width>x<options>, ImageMagick requires <width><options>
-      geometry = (this._options.imageMagick) ? w + options : w + 'x' + options;
+      if (options) {
+          // GraphicsMagick requires <width>x<options>, ImageMagick requires <width><options>
+          geometry = (this._options.imageMagick) ? w + options : w + 'x' + options;
+      } else {
+          //<width>x is not the same as <width>
+          geometry = w;
+      }
     } else if (!w && h) {
       geometry = 'x' + h + options
     }


### PR DESCRIPTION
The existing code would output the following:
gmObj.resize(345) => "-resize 345x"
which does not scale up the image to 345 pixels if the image is smaller than 345 pixels in width

The proper behavior that this patch implements is:
gmObj.resize(345) => "-resize 345"
which will scale up the image
