### PR TITLE
Make autoOrient respect order of operations

### DIFF
--- a/lib/convenience/autoOrient.js
+++ b/lib/convenience/autoOrient.js
@@ -1,4 +1,3 @@
-
 /**
  * Extend proto.
  */
@@ -43,7 +42,7 @@ module.exports = function (proto) {
           }
 
           // repage to fix coordinates
-          this._out.unshift.apply(this._out, transforms.concat('-page', '+0+0'));
+          this._out.push.apply(this._out, transforms.concat('-page', '+0+0'));
         }
 
         this.strip();


### PR DESCRIPTION
If the user wants to auto orient at the beginning, he should auto orient at the beginning. You shouldn't be doing this for him and there are use cases when we want auto orientation to occur after applying transforms.
