### PR TITLE
Fix issue #245: background('none') leads to a white background

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -1044,7 +1044,7 @@ module.exports = function (proto) {
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-background
   proto.background = function background (color) {
-    return this.out("-background", color);
+    return this.in("-background", color);
   }
 };
 

--- a/test/append.js
+++ b/test/append.js
@@ -14,11 +14,11 @@ module.exports = function (_, dir, next, gm) {
 
   var args = m.args();
   assert.equal('convert', args[0]);
-  assert.ok(/examples\/imgs\/lost\.png$/.test(args[1]));
-  assert.ok(/examples\/imgs\/original\.jpg$/,args[2]);
-  assert.ok(/examples\/imgs\/original\.jpg$/,args[3]);
-  assert.equal('-background',args[4]);
-  assert.equal('#222',args[5]);
+  assert.equal('-background',args[1]);
+  assert.equal('#222',args[2]);
+  assert.ok(/examples\/imgs\/lost\.png$/.test(args[3]));
+  assert.ok(/examples\/imgs\/original\.jpg$/,args[4]);
+  assert.ok(/examples\/imgs\/original\.jpg$/,args[5]);
   assert.equal('-append',args[6]);
   assert.equal('-',args[7]);
 

--- a/test/background.js
+++ b/test/background.js
@@ -9,10 +9,10 @@ module.exports = function (gm, dir, finish, GM) {
 
   var args = m.args();
   assert.equal('convert', args[0]);
-  assert.equal('-crop', args[2]);
-  assert.equal('140x100+0+0', args[3]);
-  assert.equal('-background', args[4]);
-  assert.equal('#FF0000', args[5]);
+  assert.equal('-background', args[1]);
+  assert.equal('#FF0000', args[2]);
+  assert.equal('-crop', args[4]);
+  assert.equal('140x100+0+0', args[5]);
   assert.equal('-extent', args[6]);
   assert.equal('340x300', args[7]);
 


### PR DESCRIPTION
The `background` property has been set as an `in` parameter as it must be used before any `source` is drawn in **gm**'s memory.

Tests have been updated accordingly.
