### PR TITLE
Added option to set ImageMagick application path explicitly

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -179,8 +179,9 @@ module.exports = function (proto) {
     */
 
   proto._spawn = function _spawn (args, bufferOutput, callback) {
+    var appPath = this._options.appPath || '';
     var bin = this._options.imageMagick
-      ? args.shift()
+      ? appPath + args.shift()
       : 'gm'
 
     var proc = spawn(bin, args)


### PR DESCRIPTION
Added option 'appPath' to allow the path of ImageMagick to be explicit set to allow direct choice of versions and avoid collision errors with application names such as on Windows (convert). Example:
    require('gm').subClass({ imageMagick: true, appPath: 'pathTo\ImageMagick-6.8.8-Q16\' })
