### PR TITLE
Compare: Add tolerance prop to options object if passed in place.

### DIFF
--- a/lib/compare.js
+++ b/lib/compare.js
@@ -30,6 +30,13 @@ module.exports = exports = function (proto) {
     // outputting the diff image
     if (typeof tolerance === 'object') {
       var diffOptions = tolerance;
+      // keep ability to pass tolerance if replaced with an options object
+      if (diffOptions.tolerance) {
+        if (typeof diffOptions.tolerance !== 'number') {
+          throw new TypeError('The value passed for tolerance is not a number');
+        }
+        tolerance = diffOptions.tolerance;
+      }
       if (typeof diffOptions.file !== 'string') {
         throw new TypeError('The path for the diff output is invalid');
       }


### PR DESCRIPTION
When calling compare, you can pass an options object with file and highlight values to create a diff image, but when you do this you loose the functionality to override the default tolerance level.
