### PR TITLE
Add tolerance to gm.compare options and always perform MSE comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Graphicsmagicks `compare` command is exposed through `gm.compare()`. This allows
 
 Currently `gm.compare` only accepts file paths.
 
-    gm.compare(path1, path2 [, tolerance], callback)
+    gm.compare(path1, path2 [, options], callback)
 
 ```js
 gm.compare('/path/to/image1.jpg', '/path/to/another.png', function (err, isEqual, equality, raw) {
@@ -506,6 +506,20 @@ You may wish to pass a custom tolerance threshold to increase or decrease the de
 
 ```js
 gm.compare('/path/to/image1.jpg', '/path/to/another.png', 1.2, function (err, isEqual) {
+  ...
+})
+```
+
+To output a diff image, pass a configuration object to define the diff options and tolerance.
+
+
+```js
+var options = {
+  file: '/path/to/diff.png',
+  highlightColor: 'yellow',
+  tolerance: 0.02
+}
+gm.compare('/path/to/image1.jpg', '/path/to/another.png', options, function (err, isEqual, equality, raw) {
   ...
 })
 ```

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -14,53 +14,52 @@ var utils = require('./utils');
  *
  * @param {String} orig Path to an image.
  * @param {String} compareTo Path to another image to compare to `orig`.
- * @param {Number} [tolerance] Amount of difference to tolerate before failing - defaults to 0.4
+ * @param {Number|Object} [options] Options object or the amount of difference to tolerate before failing - defaults to 0.4
  * @param {Function} cb(err, Boolean, equality, rawOutput)
  */
 
 module.exports = exports = function (proto) {
-  function compare(orig, compareTo, tolerance, cb) {
+  function compare(orig, compareTo, options, cb) {
     orig = utils.escape(orig);
     compareTo = utils.escape(compareTo);
 
     var isImageMagick = this._options && this._options.imageMagick;
     // compare binary for IM is `compare`, for GM it's `gm compare`
     var bin = isImageMagick ? '' : 'gm ';
-
-    // outputting the diff image
-    if (typeof tolerance === 'object') {
-      var diffOptions = tolerance;
-      if (typeof diffOptions.file !== 'string') {
-        throw new TypeError('The path for the diff output is invalid');
-      }
-      // graphicsmagick defaults to red
-      var highlightColorOption = diffOptions.highlightColor
-        ? ' -highlight-color ' + diffOptions.highlightColor + ' '
-        : ' ';
-      var diffFilename = utils.escape(diffOptions.file);
-      // For IM, filename is the last argument. For GM it's `-file <filename>`
-      var diffOpt = isImageMagick ? diffFilename : ('-file ' + diffFilename);
-      var cmd = bin + 'compare' + highlightColorOption + orig + ' ' + compareTo +
-        ' ' + diffOpt;
-
-      return exec(cmd, function (err, stdout, stderr) {
-        // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar
-        if (isImageMagick && err && err.code === 1) {
-          err = null;
-        }
-        return cb(err, stdout, stderr);
-      });
-    }
-
-    // else, output the mean square error (mse)
-    if ('function' == typeof tolerance) {
-      cb = tolerance;
-      tolerance = 0.4;
-    }
-
     var execCmd = bin + 'compare -metric mse ' + orig + ' ' + compareTo;
-    // For ImageMagick diff file is required but we don't care about it, so null it out
-    isImageMagick && (execCmd += ' null:');
+    var tolerance = 0.4
+    // outputting the diff image
+    if (typeof options === 'object') {
+      if (options.file) {
+        if (typeof options.file !== 'string') {
+          throw new TypeError('The path for the diff output is invalid');
+        }
+         // graphicsmagick defaults to red
+        var highlightColorOption = options.highlightColor
+          ? ' -highlight-color ' + options.highlightColor + ' '
+          : ' ';
+        var diffFilename = utils.escape(options.file);
+        // For IM, filename is the last argument. For GM it's `-file <filename>`
+        var diffOpt = isImageMagick ? diffFilename : ('-file ' + diffFilename);
+        execCmd += highlightColorOption + ' ' + diffOpt;
+      }
+      
+      if (options.tolerance) {
+        if (typeof options.tolerance !== 'number') {
+          throw new TypeError('The tolerance value should be a number');
+        }
+        tolerance = options.tolerance;
+      } 
+    } else {
+      // For ImageMagick diff file is required but we don't care about it, so null it out
+      isImageMagick && (execCmd += ' null:');
+
+      if (typeof options == 'function') {
+        cb = options; // tolerance value not provided, flip the cb place
+      } else {
+        tolerance = options
+      }
+    }
 
     exec(execCmd, function (err, stdout, stderr) {
       // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar

--- a/test/compare.js
+++ b/test/compare.js
@@ -13,12 +13,14 @@ module.exports = function (gm, dir, finish, GM) {
 
       var options = {
         highlightColor: 'yellow',
-        file: dir + '/diff.png'
+        file: dir + '/diff.png',
+        tolerance: 0.001
       };
 
-      // Compare these images and write to a file.
-      GM.compare(dir + '/original.jpg', dir + '/noise3.png', options, function(err) {
+      // Compare these images and write diff to a file.
+      GM.compare(dir + '/original.jpg', dir + '/noise3.png', options, function(err, same) {
         if (err) return finish(err);
+        if (!same) return finish(new Error('Compare should be the same!'));
 
         fs.exists(options.file, function(exists) {
           if (exists) finish();


### PR DESCRIPTION
The `gm.compare` does not perform actual comparison when it is provided with options object to create a diff image. I modified the `compare` options handling and simplified the logic so that it will always perform the Mean Square Error comparison.

I also added an example to the readme and slightly modified the `compare` test in order to verify that the comparison is performed.
