### PR TITLE
fix dropped "+" when 0 passed as vertical roll amt

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -1,4 +1,3 @@
-
 /**
  * Dependencies
  */
@@ -961,8 +960,8 @@ module.exports = function (proto) {
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-roll
   proto.roll = function roll (x, y) {
-    x = ((x = parseInt(x, 10) || 0) > 0 ? "+" : "") + x;
-    y = ((y = parseInt(y, 10) || 0) > 0 ? "+" : "") + y;
+    x = ((x = parseInt(x, 10) || 0) >= 0 ? "+" : "") + x;
+    y = ((y = parseInt(y, 10) || 0) >= 0 ? "+" : "") + y;
     return this.out("-roll", x+y);
   }
 


### PR DESCRIPTION
fix dropped "+" when 0 passed as vertical roll amt
