### PR TITLE
Fix for .size() not working on Node 0.10.26.

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -44,7 +44,7 @@ module.exports = function (gm) {
         , key = val.key
         , self = this;
 
-      if (self.data[key]) {
+      if (self.data.hasOwnProperty(key)) {
         callback.call(self, null, self.data[key]);
         return self;
       }


### PR DESCRIPTION
I'm new to Node, so this might not be the best fix, but I noticed that calling .size() on an image was returning a `function` as a response rather than an object with width and height parameters. I'm not sure why this was—maybe some automagic getter stuff in a newer V8?—but this patch fixes the problem for me.
