### PR TITLE
Assure that eventual spawn crash is propagated to callback

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -184,12 +184,17 @@ module.exports = function (proto) {
       ? appPath + args.shift()
       : 'gm'
 
-    var proc = spawn(bin, args)
-      , cmd = bin + ' ' + args.map(utils.escape).join(' ')
+    var cmd = bin + ' ' + args.map(utils.escape).join(' ')
       , self = this
-      , err;
+      , proc, err;
 
     debug(cmd);
+
+    try {
+      proc = spawn(bin, args);
+    } catch (e) {
+      return cb(e);
+    }
 
     if (self.sourceBuffer) {
       proc.stdin.write(this.sourceBuffer);


### PR DESCRIPTION
There's possiblity that node's `spawn` crashes, e.g. due to EMFILE error. Such error should be propagated to callback, currently it unconditionally crashes the process.
