### PR TITLE
fixes for adjoin and crop

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -25,6 +25,7 @@ module.exports = function (proto) {
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-adjoin
   proto.adjoin = function adjoin () {
+    if (arguments[0] === "+") return this.out("+adjoin");
     return this.out("-adjoin");
   }
 
@@ -763,6 +764,8 @@ module.exports = function (proto) {
       }
     }
 
+    if (x === undefined && y === undefined && percent === undefined)
+        return this.out("-crop",w + "x" + h);
     return this.out("-crop", w + "x" + h + "+" + (x || 0) + "+" + (y || 0) + (percent ? '%' : ''));
   }
 


### PR DESCRIPTION
crop(w,h) now returns '-crop <w>x<h>'
adjoin('+') returns '+adjoin'
