### PR TITLE
Listen stdin error event upon spawn failure

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -195,6 +195,7 @@ module.exports = function (proto) {
     } catch (e) {
       return cb(e);
     }
+    proc.stdin.once('error', cb);
 
     if (self.sourceBuffer) {
       proc.stdin.write(this.sourceBuffer);


### PR DESCRIPTION
This happens typically when `gm` is not available