### PR TITLE
fixes density() on ImageMagick

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -729,6 +729,11 @@ module.exports = function (proto) {
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-density
   proto.density = function density (w, h) {
+    if (w && !h && this._options.imageMagick) {
+      // GraphicsMagick requires <width>x<height>y, ImageMagick may take dpi<resolution>
+      // recommended 300dpi for higher quality
+      return this.in("-density", w);
+    }
     return this.in("-density", w +"x"+ h);
   }
 

--- a/test/densityGm.js
+++ b/test/densityGm.js
@@ -1,0 +1,28 @@
+
+var assert = require('assert');
+
+module.exports = function (gm, dir, finish, GM) {
+  'use strict';
+
+  // a two magic numbers
+  var NUMBER = 100;
+  var NUMBER2 = 200;
+
+  var g = gm.density(NUMBER, NUMBER2);
+
+  var gArgs = g.args();
+
+  assert.equal('convert', gArgs[0]);
+  assert.equal('-density', gArgs[1]);
+  assert.equal(NUMBER + 'x' + NUMBER2, gArgs[2]);
+
+  if (gm._options.imageMagick)
+    return finish();
+
+  if (!GM.integration)
+    return finish();
+
+  im.write(dir + '/density.png', function density (err) {
+    finish(err);
+  });
+};

--- a/test/densityGm.js
+++ b/test/densityGm.js
@@ -22,7 +22,7 @@ module.exports = function (gm, dir, finish, GM) {
   if (!GM.integration)
     return finish();
 
-  im.write(dir + '/density.png', function density (err) {
+  g.write(dir + '/density.png', function density (err) {
     finish(err);
   });
 };

--- a/test/densityIm.js
+++ b/test/densityIm.js
@@ -1,0 +1,28 @@
+
+var assert = require('assert');
+
+module.exports = function (gm, dir, finish, GM) {
+  'use strict';
+
+  // a magic number
+  var NUMBER = 100;
+
+  // image magic version
+  var im = gm.options({imageMagick: true}).density(NUMBER);
+
+  var imArgs = im.args();
+
+  assert.equal('convert', imArgs[0]);
+  assert.equal('-density', imArgs[1]);
+  assert.equal(NUMBER, imArgs[2]);
+
+  if (gm._options.imageMagick)
+    return finish();
+
+  if (!GM.integration)
+    return finish();
+
+  im.write(dir + '/density.png', function density (err) {
+    finish(err);
+  });
+};


### PR DESCRIPTION
on image magic density switch takes optionally one argument (dpi)
not two (w,h) like graphics magic