### PR TITLE
Improved resizing and cropping logic in thumb()

### DIFF
--- a/lib/convenience/thumb.js
+++ b/lib/convenience/thumb.js
@@ -21,51 +21,33 @@ module.exports = function (proto) {
         return callback.apply(self, arguments);
       }
 
-      w = parseInt(w, 10);
-      h = parseInt(h, 10);
+      var w1 = w = parseInt(w, 10);
+      var h1 = h = parseInt(h, 10);
 
-      var w1, h1;
       var xoffset = 0;
       var yoffset = 0;
+      var xratio = w / size.width;
+      var yratio = h / size.height;
 
-      if (size.width < size.height) {
-        w1 = w;
-        h1 = Math.floor(size.height * (w/size.width));
-        if (h1 < h) {
-          w1 = Math.floor(w1 * (((h-h1)/h) + 1));
-          h1 = h;
-        }
-      } else if (size.width > size.height) {
-        h1 = h;
-        w1 = Math.floor(size.width * (h/size.height));
-        if (w1 < w) {
-          h1 = Math.floor(h1 * (((w-w1)/w) + 1));
-          w1 = w;
-        }
-      } else if (size.width == size.height) {
-        var bigger = (w>h?w:h);
-        w1 = bigger;
-        h1 = bigger;
+      if (xratio > yratio) {
+        h1 = Math.ceil(xratio * size.height);
+      } else {
+        w1 = Math.ceil(yratio * size.width);
       }
 
-      if (align == 'center') {
-        if (w < w1) {
-          xoffset = (w1-w)/2;
-        }
-        if (h < h1) {
-          yoffset = (h1-h)/2;
-        }
+      if (align === 'center') {
+        xoffset = Math.floor((w1 - w) / 2);
+        yoffset = Math.floor((h1 - h) / 2);
       }
 
       self
-      .quality(quality)
-      .in("-size", w1+"x"+h1)
-      .scale(w1, h1)
-      .crop(w, h, xoffset, yoffset)
-      .noProfile()
-      .write(name, function () {
-        callback.apply(self, arguments)
-      });
+        .quality(quality)
+        .scale(w1, h1)
+        .crop(w, h, xoffset, yoffset)
+        .noProfile()
+        .write(name, function () {
+          callback.apply(self, arguments)
+        });
     });
 
     return self;


### PR DESCRIPTION
In certain cases, I was getting thumbs with heights ranging from 1 to 12 pixels shorter than the height provided to `.thumb()`.
