### PR TITLE
Update debug to ^2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_install:
   - sudo apt-get update
   - sudo apt-get install imagemagick graphicsmagick
+  - npm update -g npm
 language: node_js
 node_js:
   - "0.8"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "async": "~0.2.7"
   },
   "dependencies": {
-    "debug": "0.7.0",
+    "debug": "^2.1.1",
     "array-series": "~0.1.0",
     "array-parallel": "~0.1.0",
     "through": "~2.3.1"


### PR DESCRIPTION
When using `gm` in `nodewebkit`, `debug` version 0.7.0 errors with `invalid invocation`.