### PR TITLE
Add progressive functionality to thumb

### DIFF
--- a/lib/convenience/thumb.js
+++ b/lib/convenience/thumb.js
@@ -5,7 +5,7 @@
 
 module.exports = function (proto) {
 
-  proto.thumb = function thumb (w, h, name, quality, align, callback) {
+  proto.thumb = function thumb (w, h, name, quality, align, progressive, callback) {
     var self = this
       , args = Array.prototype.slice.call(arguments);
 
@@ -15,6 +15,7 @@ module.exports = function (proto) {
     name = args.shift();
     quality = args.shift() || 63;
     align = args.shift() || 'topleft';
+    var interlace = args.shift() ? 'Line' : 'None';
 
     self.size(function (err, size) {
       if (err) {
@@ -62,6 +63,7 @@ module.exports = function (proto) {
       .in("-size", w1+"x"+h1)
       .scale(w1, h1)
       .crop(w, h, xoffset, yoffset)
+      .interlace(interlace)
       .noProfile()
       .write(name, function () {
         callback.apply(self, arguments)


### PR DESCRIPTION
You can make the output jpeg progressive by passing true for `progressive` argument.