### PR TITLE
add option to use gm’s auto-orient

### DIFF
--- a/lib/convenience/autoOrient.js
+++ b/lib/convenience/autoOrient.js
@@ -22,8 +22,8 @@ module.exports = function (proto) {
 
     // imagemagick has a native -auto-orient option
     // so does graphicsmagick, but in 1.3.18.
-    // apt doesn't release this version yet.
-    if (this._options.imageMagick) {
+    // nativeAutoOrient option enables this if you know you have >= 1.3.18
+    if (this._options.nativeAutoOrient || this._options.imageMagick) {
       this.out('-auto-orient');
       this.strip();
       return this;


### PR DESCRIPTION
Buffering the image to get its orientation is slow. Since newer gm's have `-auto-orient`, provide an option to use it. Depending on usage and package status now, it may make sense to reverse this option.