### PR TITLE
Leverage appPath option to supply full executable path

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -213,7 +213,7 @@ module.exports = function (proto) {
     var appPath = this._options.appPath || '';
     var bin = this._options.imageMagick
       ? appPath + args.shift()
-      : 'gm'
+      : appPath + 'gm'
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')
       , self = this


### PR DESCRIPTION
It's useful to be able to specify the full executable path on some Windows systems, this change leverages the existing appPath option.

I'm using it as follows:

```javascript
gm(data)
	.options({appPath:"C:/Program Files/GraphicsMagick-1.3.21-Q8/"})
	.resize('300>')
	.toBuffer(function (err, buffer) {
				// do stuff
			});