### PR TITLE
Ignoring warning messages for identify.

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -204,7 +204,7 @@ module.exports = function (gm) {
         var indent = res[1].length
           , key = res[2] ? res[2].trim() : '';
 
-        if ('Image' == key) continue;
+        if ('Image' == key || 'Warning' == key) continue;
 
         var val = res[3] ? res[3].trim() : null;
 


### PR DESCRIPTION
When the PDF has issues and an warning is generated for stdout, gm puts the image attributes inside an "Warning" key. This patch ignores the warning and leave the output object as it would be as if there were no warnings.