### PR TITLE
Add timeout support

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -217,7 +217,9 @@ module.exports = function (proto) {
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')
       , self = this
-      , proc, err;
+      , proc, err
+      , timeout = parseInt(this._options.timeout)
+      , timeoutId;
 
     debug(cmd);
 
@@ -227,6 +229,17 @@ module.exports = function (proto) {
       return cb(e);
     }
     proc.stdin.once('error', cb);
+
+    if (timeout) {
+      timeoutId = setTimeout(function(){
+        err = new Error('gm() resulted in a timeout.');
+        cb(err);
+        if (proc.connected) {
+          proc.stdin.pause();
+          proc.kill();
+        }
+      }, timeout);
+    }
 
     if (self.sourceBuffer) {
       proc.stdin.write(this.sourceBuffer);
@@ -300,6 +313,7 @@ module.exports = function (proto) {
 
     function cb (err, stdout, stderr, cmd) {
       if (cb.called) return;
+      if (timeoutId) clearTimeout(timeoutId);
       cb.called = 1;
 			if (args[0] !== 'identify' && bin !== 'identify') {
 				self._in = [];

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,0 +1,33 @@
+
+var assert = require('assert')
+
+module.exports = function (img, dir, finish, gm) {
+
+  assert.equal(undefined, gm.prototype._options.timeout);
+  assert.equal(undefined, img._options.timeout);
+
+  var g = gm('test').options({ timeout: 100 });
+  assert.equal(100, g._options.timeout);
+
+  var sub = gm.subClass({ timeout: 2000 });
+  assert.equal(2000, sub.prototype._options.timeout);
+
+
+  if (!gm.integration)
+    return finish();
+
+  gm(dir + '/photo.JPG').options({ timeout: 1 })
+  .thumb(50, 80, dir + '/timeout.png', function subthumb (err) {
+    assert.ok(err, "Expecting a timeout error");
+    noTimeout();
+  });
+
+
+  function noTimeout() {
+    gm(dir + '/photo.JPG').options({ timeout: 0 })
+    .thumb(50, 80, dir + '/timeout.png', function subthumb (err) {
+      finish(err);
+    });
+  }
+
+}


### PR DESCRIPTION
This pull request adds a timeout option to the gm instance.
The timeout is a value in milliseconds. You can also pass strings.
e.g.
```
gm(dir + '/photo.JPG').options({ timeout: 1000 })
```