### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ gm('/path/to/my/img.jpg')
 
 // combine the two for true streaming image processing
 var readStream = fs.createReadStream('/path/to/my/img.jpg');
-gm(readStream, 'img.jpg')
+gm(readStream)
 .resize('200', '200')
 .stream(function (err, stdout, stderr) {
   var writeStream = fs.createWriteStream('/path/to/my/resized.jpg');
@@ -164,7 +164,7 @@ gm(readStream, 'img.jpg')
 // you also need to convert (write() or stream()) the image afterwards
 // NOTE: this buffers the readStream in memory!
 var readStream = fs.createReadStream('/path/to/my/img.jpg');
-gm(readStream, 'img.jpg')
+gm(readStream)
 .size({bufferStream: true}, function(err, size) {
   this.resize(size.width / 2, size.height / 2)
   this.write('/path/to/resized.jpg', function (err) {


### PR DESCRIPTION
removed file names in streaming examples -- they are unnecessary and causes confusion for first-time users of the api