### PR TITLE
Add {timeout:n} option to prevent GM running forever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/imgs/*
 !examples/imgs/orientation/*.correct.jpg
 *.sw*
 .idea
+/.project

--- a/lib/command.js
+++ b/lib/command.js
@@ -215,6 +215,17 @@ module.exports = function (proto) {
 
     try {
       proc = spawn(bin, args);
+      if (self._options.timeout) {
+    	  proc.once('exit',function(){
+    		  if (timer)
+    			  clearTimeout(timer) ;
+    		  timer = null ;
+    	  }) ;
+    	  var timer = setTimeout(function(){
+    		  timer = null ;
+    		  proc.kill('SIGKILL') ;
+    	  },self._options.timeout) ;
+      }
     } catch (e) {
       return cb(e);
     }

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -64,7 +64,12 @@ module.exports = exports = function (proto) {
       }
     }
 
-    exec(execCmd, function (err, stdout, stderr) {
+    var options = {} ;
+    if (this._options.timeout) {
+    	options.timeout = this._spawnTimeout ;
+    	options.killSignal = 'SIGKILL' ;
+    }
+    exec(execCmd, options, function (err, stdout, stderr) {
       // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar
       if (isImageMagick) {
         if (!err) {

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -66,7 +66,7 @@ module.exports = exports = function (proto) {
 
     var options = {} ;
     if (this._options.timeout) {
-    	options.timeout = this._spawnTimeout ;
+    	options.timeout = this._options.timeout ;
     	options.killSignal = 'SIGKILL' ;
     }
     exec(execCmd, options, function (err, stdout, stderr) {


### PR DESCRIPTION
We have a production issue in that sometimes gm hangs, and we end up with 100s of instances running. This option allows us to specify a timeout, and kills the spawned process if it doesn't terminate within that time:

````

// Make sure gm terminates, one way or the other, after 1 second
var g = gm('file.jpg').options({timeout:1000}) ;

````
