### PR TITLE
add tint functionality

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -165,6 +165,11 @@ module.exports = function (proto) {
     return this.out("-colorize", [r,g,b].join(","));
   }
 
+  // tint doesn't seem to exist on GraphicsMagick
+  proto.tint = function tint (r, g, b) {
+    return this.out("-tint", [r,g,b].join(","));
+  }
+
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-colormap
   proto.colorMap = function colorMap (type) {
     return this.out("-colormap", type);


### PR DESCRIPTION
add support for the `-tint` function.

GraphicsMagick doesn't seem to support it, but it is supported by ImageMagick.

`tint` has the same interface as `colorize`, but it seems to behave differently, at least on Ubuntu 14.04. I had problems with `colorize` colouring the areas of the image that is totally transparent, whereas `tint` works as expected and leaves these areas alone. This is also how `colorize` behaves on OS X 10.10.

