### PR TITLE
gm calls "identify -verbose" to obtain image orientation

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -27,7 +27,7 @@ module.exports = function (gm) {
     , 'filesize': { key: 'Filesize', format: '%b' }
     , 'size':  { key: 'size', format: '%wx%h ', helper: 'Geometry' }
     , 'color': { key: 'color', format: '%k',  helper: 'Colors' }
-    , 'orientation': { key: 'Orientation', verbose: true }
+    , 'orientation': { key: 'Orientation', format: '%[EXIF:Orientation]', helper: 'Orientation' }
     , 'res':   { key: 'Resolution', verbose: true }
   }
 
@@ -271,6 +271,21 @@ module.exports = function (gm) {
   }
 
   /**
+   * Map exif orientation codes to orientation names.
+   */
+
+  var orientations = {
+      '1': 'TopLeft'
+    , '2': 'TopRight'
+    , '3': 'BottomRight'
+    , '4': 'BottomLeft'
+    , '5': 'LeftTop'
+    , '6': 'RightTop'
+    , '7': 'RightBottom'
+    , '8': 'LeftBottom'
+  }
+
+  /**
    * identify -verbose helpers
    */
 
@@ -296,5 +311,15 @@ module.exports = function (gm) {
 
   helper.Colors = function Colors (o, val) {
     o.color = parseInt(val, 10);
+  };
+
+  helper.Orientation = function Orientation (o, val) {
+    if (val in orientations) {
+      o['Profile-EXIF'] || (o['Profile-EXIF'] = {});
+      o['Profile-EXIF'].Orientation = val;
+      o.Orientation = orientations[val];
+    } else {
+      o.Orientation = val || 'Unknown';
+    }
   };
 }

--- a/test/autoOrient.js
+++ b/test/autoOrient.js
@@ -14,7 +14,6 @@ module.exports = function (_, dir, finish, gm) {
 
     assert.equal('RightTop', o);
     assert.ok(!! this.data['Profile-EXIF'], 'No Profile-EXIF data found');
-    assert.equal('155x460', this.data.Geometry);
 
     // this image is sideways, but may be auto-oriented by modern OS's
     // try opening it in a browser to see its true orientation

--- a/test/autoOrientAll.js
+++ b/test/autoOrientAll.js
@@ -72,7 +72,6 @@ module.exports = function (_, dir, finish, gm) {
 
         assert.equal(beforeValues[filename][0], o);
         assert.equal(beforeValues[filename][1], this.data['Profile-EXIF'].Orientation, 'No Profile-EXIF data found');
-        assert.equal(beforeValues[filename][2], this.data.Geometry);
 
         // this image is sideways, but may be auto-oriented by modern OS's
         // try opening it in a browser to see its true orientation

--- a/test/autoOrientStream.js
+++ b/test/autoOrientStream.js
@@ -16,7 +16,6 @@ module.exports = function (_, dir, finish, gm) {
 
     assert.equal('RightTop', o);
     assert.ok(!! this.data['Profile-EXIF'], 'No Profile-EXIF data found');
-    assert.equal('155x460', this.data.Geometry);
 
     // this image is sideways, but may be auto-oriented by modern OS's
     // try opening it in a browser to see its true orientation


### PR DESCRIPTION
Right now both `.orientation()` and `.autoOrient()` methods result in calling very slow and inefficient

    gm identify -verbose

which runs a deep analysis of the image, including gathering detailed statistics on each channel.

It would be much more efficient to checking Exif orientation metadata instead

    gm identify -format %[EXIF:Orientation]