### PR TITLE
fixing test/getterFilesize

### DIFF
--- a/test/getterFilesize.js
+++ b/test/getterFilesize.js
@@ -10,7 +10,7 @@ module.exports = function (gm, dir, finish, GM) {
     if (err) return finish(err);
 
     if (this._options.imageMagick) {
-      assert.equal('7792B', size, size);
+      assert.equal('7.79KB', size, size);
     } else {
       assert.ok(/7.6K[i]{0,1}/.test(size));
     }
@@ -27,7 +27,7 @@ module.exports = function (gm, dir, finish, GM) {
       if (err) return finish(err);
 
       if (this._options.imageMagick) {
-        assert.equal('7792B', size, size);
+        assert.equal('7.79KB', size, size);
       } else {
         assert.ok(/7.6K[i]{0,1}/.test(size));
       }


### PR DESCRIPTION
Not sure why but now the size is being returned in KB instead of B.

```

assert.js:86
  throw new assert.AssertionError({
        ^
AssertionError: 7.79KB
    at gm.getterfilesize (/Users/dan/Documents/qwertee/gm/test/getterFilesize.js:13:14)
    at gm.emit (events.js:110:17)
    at gm.<anonymous> (/Users/dan/Documents/qwertee/gm/lib/getters.js:82:14)
    at cb (/Users/dan/Documents/qwertee/gm/lib/command.js:318:16)
    at ChildProcess.proc.on.onExit (/Users/dan/Documents/qwertee/gm/lib/command.js:293:9)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1015:16)
    at Socket.<anonymous> (child_process.js:1183:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:485:12)
make: *** [test] Error 1

```

The ugly part @rwky is this error now happening when running `npm test` (and after changing that assert failing):

```
All tests passed
pending 2

Error occured with file: /Users/dan/Documents/qwertee/gm/test/webp.js
/Users/dan/Documents/qwertee/gm/test/index.js:40
      throw err;
            ^
Error: Command failed: convert: delegate failed `"cwebp" -quiet -q %Q "%i" -o "%o"' @ error/delegate.c/InvokeDelegate/1329.

    at ChildProcess.proc.on.onExit (/Users/dan/Documents/qwertee/gm/lib/command.js:289:17)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1015:16)
    at Socket.<anonymous> (child_process.js:1183:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:485:12)
make: *** [test] Error 1
npm ERR! Test failed.  See above for more details.

```

any idea how to solve it?