### PR TITLE
Allow gm to know PID externally

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ util.inherits(gm, EventEmitter);
  */
 
 function gm (source, height, color) {
-  var width;
-  var pid;
+  var width, pid = 0
 
   if (!(this instanceof gm)) {
     return new gm(source, height, color);
@@ -27,14 +26,14 @@ function gm (source, height, color) {
 
   EventEmitter.call(this);
 
-  this.on("pid-announce", function(data) {
+  this.on("pid-announce", function (data) {
     this.pid = data.pid
-    console.log(this.pid)
-  });
+  })
 
-  this.sharePid = function(pid){
-    this.emit("pid-announce", {pid:pid});
+  this.sharePid = function (pid) {
+    this.emit("pid-announce", {pid: pid});
   }
+
 
   this._options = {};
   this.options(this.__proto__._options);
@@ -108,7 +107,6 @@ gm.subClass = function subClass (options) {
 
     parent.call(this, source, height, color);
   }
-
   gm.prototype.__proto__ = parent.prototype;
   gm.prototype._options = {};
   gm.prototype.options(options);
@@ -129,6 +127,7 @@ require("./lib/command")(gm.prototype);
 require("./lib/compare")(gm.prototype);
 require("./lib/composite")(gm.prototype);
 require("./lib/montage")(gm.prototype);
+//require("./lib/pid")(gm.prototype);
 
 /**
  * Expose.

--- a/index.js
+++ b/index.js
@@ -19,12 +19,22 @@ util.inherits(gm, EventEmitter);
 
 function gm (source, height, color) {
   var width;
+  var pid;
 
   if (!(this instanceof gm)) {
     return new gm(source, height, color);
   }
 
   EventEmitter.call(this);
+
+  this.on("pid-announce", function(data) {
+    this.pid = data.pid
+    console.log(this.pid)
+  });
+
+  this.sharePid = function(pid){
+    this.emit("pid-announce", {pid:pid});
+  }
 
   this._options = {};
   this.options(this.__proto__._options);

--- a/lib/command.js
+++ b/lib/command.js
@@ -221,6 +221,7 @@ module.exports = function (proto) {
     }
     try {
       proc = spawn(bin, args);
+      this.sharePid(proc.pid);
     } catch (e) {
       return cb(e);
     }


### PR DESCRIPTION
I have augmented gm to externally notify pid to caller via .on("pid-announce") event.

I haven't written tests for it yet, but if gm works, we should have the process id of the spawned child proc.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/aheckmann/gm/444)
<!-- Reviewable:end -->
