### PR TITLE
Fix a filename typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ gm('/path/to/my/img.jpg')
 // gm will provide image data in that format
 gm('/path/to/my/img.jpg')
 .stream('png', function (err, stdout, stderr) {
-  var writeStream = fs.createWriteStream('/path/to/my/reformated.png');
+  var writeStream = fs.createWriteStream('/path/to/my/reformatted.png');
   stdout.pipe(writeStream);
 });
 
 // or without the callback
-var writeStream = fs.createWriteStream('/path/to/my/reformated.png');
+var writeStream = fs.createWriteStream('/path/to/my/reformatted.png');
 gm('/path/to/my/img.jpg')
 .stream('png')
 .pipe(writeStream);


### PR DESCRIPTION
Hey @aheckmann! I found a mistake in the file name while reading through the doc.

'/path/to/my/reformated.png' to '/path/to/my/reformatted.png'

Keep up the good work!