### PR TITLE
feat(command): add nice option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ gm(200, 400, "#ddff99f3")
 .write("/path/to/brandNewImg.jpg", function (err) {
   // ...
 });
+
+// nice
+gm('/path/to/my/img.jpg')
+.options({nice: 10})
+.write('/path/to/resize.png', function (err) {
+  if (!err) console.log('done');
+});
 ```
 
 ## Streams

--- a/lib/command.js
+++ b/lib/command.js
@@ -35,7 +35,7 @@ module.exports = function (proto) {
       return this;
     }
   }
-  
+
   function streamToUnemptyBuffer(stream, callback) {
     var done = false
     var buffers = []
@@ -54,7 +54,7 @@ module.exports = function (proto) {
       buffers = null
       if (result.length==0)
       {
-          err = new Error("Stream yields empty buffer"); 
+          err = new Error("Stream yields empty buffer");
           callback(err, null);
       } else {
           callback(null, result);
@@ -196,7 +196,7 @@ module.exports = function (proto) {
     * @param {Array} args
     * @param {ReadableStream} stream
     * @param {Boolean} shouldBuffer
-    * @param {Function} callback, signature (err, stdout, stderr) -> * 
+    * @param {Function} callback, signature (err, stdout, stderr) -> *
     * @return {Object} gm
     * @TODO refactor this mess
     */
@@ -206,6 +206,12 @@ module.exports = function (proto) {
     var bin = this._options.imageMagick
       ? appPath + args.shift()
       : appPath + 'gm'
+
+    if(this._options.nice) {
+      args.unshift(bin);
+      args.unshift('-n ' + this._options.nice * 1);
+      bin = 'nice';
+    }
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')
       , self = this


### PR DESCRIPTION
Added a new `nice` option to ease CPU load (using `nice`) when gm is used in the background of other critical tasks.