### PR TITLE
Added progress on monitor() - progress support #239

### DIFF
--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -1,0 +1,14 @@
+var gm = require('../'),
+	dir = __dirname + '/imgs',
+	out = dir + '/mon.jpg';
+
+gm(dir + '/original.jpg')
+	.monitor()
+	.resize(9000, 9000)
+	.resizeExact(240, 240)
+	.autoOrient()
+	.flip()
+	.write(out, function(err) {
+		if (err) return console.dir(err)
+			//console.log(this.outname + " created  ::  " + arguments[3])
+	})

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ util.inherits(gm, EventEmitter);
  * @param {String} [color] - optional hex background color of created img
  */
 
-function gm (source, height, color) {
+function gm(source, height, color) {
   var width;
 
   if (!(this instanceof gm)) {
@@ -49,7 +49,7 @@ function gm (source, height, color) {
     this.in("-size", width + "x" + height);
 
     if (color) {
-      this.in("xc:"+ color);
+      this.in("xc:" + color);
     }
   }
 
@@ -68,7 +68,7 @@ function gm (source, height, color) {
 
   this.source = source;
 
-  this.addSrcFormatter(function (src) {
+  this.addSrcFormatter(function(src) {
     // must be first source formatter
 
     var inputFromStdin = this.sourceStream || this.sourceBuffer;
@@ -89,8 +89,8 @@ function gm (source, height, color) {
  */
 
 var parent = gm;
-gm.subClass = function subClass (options) {
-  function gm (source, height, color) {
+gm.subClass = function subClass(options) {
+  function gm(source, height, color) {
     if (!(this instanceof parent)) {
       return new gm(source, height, color);
     }
@@ -118,6 +118,7 @@ require("./lib/command")(gm.prototype);
 require("./lib/compare")(gm.prototype);
 require("./lib/composite")(gm.prototype);
 require("./lib/montage")(gm.prototype);
+require("./lib/monitor")(gm.prototype);
 
 /**
  * Expose.

--- a/lib/command.js
+++ b/lib/command.js
@@ -19,32 +19,35 @@ var noBufferConcat = 'gm v1.9.0+ required node v0.8+. Please update your version
  * Extend proto
  */
 
-module.exports = function (proto) {
+module.exports = function(proto) {
 
-  function args (prop) {
-    return function args () {
+  function args(prop) {
+    return function args() {
       var len = arguments.length;
       var a = [];
       var i = 0;
 
       for (; i < len; ++i) {
         a.push(arguments[i]);
+        //Add command for monitoring
+        this.addMonitorCommand(arguments[i]);
+        //console.log(arguments[]);
       }
 
       this[prop] = this[prop].concat(a);
       return this;
     }
   }
-  
+
   function streamToUnemptyBuffer(stream, callback) {
     var done = false
     var buffers = []
 
-    stream.on('data', function (data) {
+    stream.on('data', function(data) {
       buffers.push(data)
     })
 
-    stream.on('end', function () {
+    stream.on('end', function() {
       var result, err;
       if (done)
         return
@@ -54,14 +57,14 @@ module.exports = function (proto) {
       buffers = null
       if (result.length==0)
       {
-          err = new Error("Stream yields empty buffer"); 
-          callback(err, null);
+        err = new Error("Stream yields empty buffer");
+        callback(err, null);
       } else {
-          callback(null, result);
+        callback(null, result);
       }
     })
 
-    stream.on('error', function (err) {
+    stream.on('error', function(err) {
       done = true
       buffers = null
       callback(err)
@@ -82,7 +85,7 @@ module.exports = function (proto) {
    * @return {Object} gm
    */
 
-  proto.write = function write (name, callback) {
+  proto.write = function write(name, callback) {
     if (!callback) callback = name, name = null;
 
     if ("function" !== typeof callback) {
@@ -96,7 +99,7 @@ module.exports = function (proto) {
     this.outname = name;
 
     var self = this;
-    this._preprocess(function (err) {
+    this._preprocess(function(err) {
       if (err) return callback(err);
       self._spawn(self.args(), true, callback);
     });
@@ -113,7 +116,7 @@ module.exports = function (proto) {
    * @return {Stream}
    */
 
-  proto.stream = function stream (format, callback) {
+  proto.stream = function stream(format, callback) {
     if (!callback && typeof format === 'function') {
       callback = format;
       format = null;
@@ -123,7 +126,7 @@ module.exports = function (proto) {
 
     if ("function" !== typeof callback) {
       throughStream = new PassThrough();
-      callback = function (err, stdout, stderr) {
+      callback = function(err, stdout, stderr) {
         if (err) throughStream.emit('error', err);
         else stdout.pipe(throughStream);
       }
@@ -135,7 +138,7 @@ module.exports = function (proto) {
     }
 
     var self = this;
-    this._preprocess(function (err) {
+    this._preprocess(function(err) {
       if (err) return callback(err);
       return self._spawn(self.args(), false, callback);
     });
@@ -152,14 +155,14 @@ module.exports = function (proto) {
    * @return {null}
    */
 
-  proto.toBuffer = function toBuffer (format, callback) {
+  proto.toBuffer = function toBuffer(format, callback) {
     if (!callback) callback = format, format = null;
 
     if ("function" !== typeof callback) {
       throw new Error('gm().toBuffer() expects a callback.');
     }
 
-    return this.stream(format, function (err, stdout) {
+    return this.stream(format, function(err, stdout) {
       if (err) return callback(err);
 
       streamToUnemptyBuffer(stdout, callback);
@@ -167,41 +170,41 @@ module.exports = function (proto) {
   }
 
   /**
-    * Run any preProcessor functions in series. Used by autoOrient.
-    *
-    * @param {Function} callback
-    * @return {Object} gm
-    */
+   * Run any preProcessor functions in series. Used by autoOrient.
+   *
+   * @param {Function} callback
+   * @return {Object} gm
+   */
 
-  proto._preprocess = function _preprocess (callback) {
+  proto._preprocess = function _preprocess(callback) {
     series(this._preprocessor, this, callback);
   }
 
   /**
-    * Execute the command, buffer input and output, return stdout and stderr buffers.
-    *
-    * @param {String} bin
-    * @param {Array} args
-    * @param {Function} callback
-    * @return {Object} gm
-    */
+   * Execute the command, buffer input and output, return stdout and stderr buffers.
+   *
+   * @param {String} bin
+   * @param {Array} args
+   * @param {Function} callback
+   * @return {Object} gm
+   */
 
-  proto._exec = function _exec (args, callback) {
+  proto._exec = function _exec(args, callback) {
     return this._spawn(args, true, callback);
   }
 
   /**
-    * Execute the command with stdin, returning stdout and stderr streams or buffers.
-    * @param {String} bin
-    * @param {Array} args
-    * @param {ReadableStream} stream
-    * @param {Boolean} shouldBuffer
-    * @param {Function} callback, signature (err, stdout, stderr) -> * 
-    * @return {Object} gm
-    * @TODO refactor this mess
-    */
+   * Execute the command with stdin, returning stdout and stderr streams or buffers.
+   * @param {String} bin
+   * @param {Array} args
+   * @param {ReadableStream} stream
+   * @param {Boolean} shouldBuffer
+   * @param {Function} callback, signature (err, stdout, stderr) -> *
+   * @return {Object} gm
+   * @TODO refactor this mess
+   */
 
-  proto._spawn = function _spawn (args, bufferOutput, callback) {
+  proto._spawn = function _spawn(args, bufferOutput, callback) {
     var appPath = this._options.appPath || '';
     var bin = this._options.imageMagick
       ? appPath + args.shift()
@@ -215,19 +218,23 @@ module.exports = function (proto) {
 
     debug(cmd);
     //imageMagick does not support minify (https://github.com/aheckmann/gm/issues/385)
-    if(args.indexOf("-minify") > -1 && this._options.imageMagick){
+    if (args.indexOf("-minify") > -1 && this._options.imageMagick) {
       err = new Error("imageMagick does not support minify, use -scale or -sample. Alternatively, use graphicsMagick");
       return cb(err);
     }
     try {
       proc = spawn(bin, args);
+      //Trigger monitor() output
+      if (args.indexOf("-monitor") > -1) {
+        this.enableMonitor(proc);
+      }
     } catch (e) {
       return cb(e);
     }
     proc.stdin.once('error', cb);
 
     if (timeout) {
-      timeoutId = setTimeout(function(){
+      timeoutId = setTimeout(function() {
         err = new Error('gm() resulted in a timeout.');
         cb(err);
         if (proc.connected) {
@@ -260,7 +267,7 @@ module.exports = function (proto) {
         // we only need one
         self._buffering = true;
 
-        streamToUnemptyBuffer(self.sourceStream, function (err, buffer) {
+        streamToUnemptyBuffer(self.sourceStream, function(err, buffer) {
           self.sourceBuffer = buffer;
           self.sourceStream = null; // The stream is now dead
         })
@@ -276,15 +283,15 @@ module.exports = function (proto) {
         , onErr
         , onExit
 
-      proc.stdout.on('data', onOut = function (data) {
+      proc.stdout.on('data', onOut = function(data) {
         stdout += data;
       });
 
-      proc.stderr.on('data', onErr = function (data) {
+      proc.stderr.on('data', onErr = function(data) {
         stderr += data;
       });
 
-      proc.on('close', onExit = function (code, signal) {
+      proc.on('close', onExit = function(code, signal) {
         if (code !== 0 || signal !== null) {
           err = new Error('Command failed: ' + stderr);
           err.code = code;
@@ -294,9 +301,9 @@ module.exports = function (proto) {
         stdout = stderr = onOut = onErr = onExit = null;
       });
 
-      proc.on('error', function(err){
+      proc.on('error', function(err) {
         if (err.code === 'ENOENT') {
-          cb(new Error('Could not execute GraphicsMagick/ImageMagick: '+cmd+" this most likely means the gm/convert binaries can't be found"));
+          cb(new Error('Could not execute GraphicsMagick/ImageMagick: ' + cmd + " this most likely means the gm/convert binaries can't be found"));
         } else {
           cb(err);
         }
@@ -307,14 +314,14 @@ module.exports = function (proto) {
 
     return self;
 
-    function cb (err, stdout, stderr, cmd) {
+    function cb(err, stdout, stderr, cmd) {
       if (cb.called) return;
       if (timeoutId) clearTimeout(timeoutId);
       cb.called = 1;
-			if (args[0] !== 'identify' && bin !== 'identify') {
-				self._in = [];
-				self._out = [];
-			}
+      if (args[0] !== 'identify' && bin !== 'identify') {
+        self._in = [];
+        self._out = [];
+      }
       callback.call(self, err, stdout, stderr, cmd);
     }
   }
@@ -325,9 +332,9 @@ module.exports = function (proto) {
    * @return {Array}
    */
 
-  proto.args = function args () {
+  proto.args = function args() {
     var outname = this.outname || "-";
-  	if (this._outputFormat) outname = this._outputFormat + ':' + outname;
+    if (this._outputFormat) outname = this._outputFormat + ':' + outname;
 
     return [].concat(
         this._subCommand
@@ -349,7 +356,7 @@ module.exports = function (proto) {
    * @return {gm} this
    */
 
-  proto.addSrcFormatter = function addSrcFormatter (formatter) {
+  proto.addSrcFormatter = function addSrcFormatter(formatter) {
     if ('function' != typeof formatter)
       throw new TypeError('sourceFormatter must be a function');
     this._sourceFormatters || (this._sourceFormatters = []);
@@ -363,7 +370,7 @@ module.exports = function (proto) {
    * @return {Array}
    */
 
-  proto.src = function src () {
+  proto.src = function src() {
     var arr = [];
     for (var i = 0; i < this._sourceFormatters.length; ++i) {
       this._sourceFormatters[i].call(this, arr);
@@ -397,7 +404,7 @@ module.exports = function (proto) {
    *   if (this.inputIs('png')) ...
    */
 
-  proto.inputIs = function inputIs (type) {
+  proto.inputIs = function inputIs(type) {
     if (!type) return false;
 
     var rgx = types[type];

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -1,0 +1,52 @@
+// monitor
+
+var utils = require('./utils');
+
+/**
+ * Provide basic user feedback when using .monitor(): pipe raw io from spawned process (broker CLI output so it's visible) and wrap inside comments (rough command count for entire job).
+ * });
+ *
+ * @param {Array} commandsList Names of callable API functions
+ * @param {Function} enableMonitor(flag) Trigger the output
+ * @param {Function} addMonitorCommand(proc) Check if arg/flag is callable and save
+ */
+
+//TODO
+/*
+-Problem here is we cannot access progress information from bin, so best we can do (without string-fiddling - "*100%*" anyone?) is give a general idea of status / activity.
+- Number of commands shown is not entirely accurate as switches are included (for now), and should not treated as part of the whole job. We could maintain a list of commands to include in args.js in future -this is a start.
+*/
+
+var commandsList = [];
+
+module.exports = exports = function(proto) {
+
+  proto.enableMonitor = function(proc) {
+
+    //Pipe to main out
+    proc.stdout.pipe(process.stdout);
+    proc.stderr.pipe(process.stderr);
+
+    //don't count -monitor as command
+    commandsList.splice(commandsList.indexOf('monitor'), 1);
+
+    //List commands running in this job
+    console.log('Processing ' + (commandsList.length - 1) + ' commands ' + '(' + commandsList.toString() + ',[+out])...');
+
+    proc.on('exit', function(code) {
+      console.log('...done.');
+    });
+
+  }
+
+  //If flag (from args) is a callable function, keep track of it as a job progress.
+  proto.addMonitorCommand = function(flag) {
+    var flag = utils.lettersOnly(flag);
+    if (!utils.isEmpty(flag) && (typeof(eval('this.' + flag)) === 'function')) {
+      commandsList.push(flag);
+      return flag;
+    } else {
+      return false;
+    }
+  };
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,37 +7,60 @@
  * @api public
  */
 
-exports.escape = function escape (arg) {
-  return '"' + String(arg).trim().replace(/"/g, '\\"') + '"';
+exports.escape = function escape(arg) {
+	return '"' + String(arg).trim().replace(/"/g, '\\"') + '"';
 };
 
-exports.unescape = function escape (arg) {
-    return String(arg).trim().replace(/"/g, "");
+exports.unescape = function escape(arg) {
+	return String(arg).trim().replace(/"/g, "");
 };
 
-exports.argsToArray = function (args) {
-  var arr = [];
-
-  for (var i = 0; i <= arguments.length; i++) {
-    if ('undefined' != typeof arguments[i])
-      arr.push(arguments[i]);
-  }
-
-  return arr;
+exports.lettersOnly = function(arg) {
+	return String(arg).trim().replace(/[^A-Za-z]/ig, "");
 };
 
-exports.isUtil = function (v) {
+exports.argsToArray = function(args) {
+	var arr = [];
+
+	for (var i = 0; i <= arguments.length; i++) {
+		if ('undefined' != typeof arguments[i])
+			arr.push(arguments[i]);
+	}
+
+	return arr;
+};
+
+exports.isUtil = function(v) {
 	var ty = 'object';
 	switch (Object.prototype.toString.call(v)) {
-	case '[object String]':
-		ty = 'String';
-		break;
-	case '[object Array]':
-		ty = 'Array';
-		break;
-	case '[object Boolean]':
-		ty = 'Boolean';
-		break;
+		case '[object String]':
+			ty = 'String';
+			break;
+		case '[object Array]':
+			ty = 'Array';
+			break;
+		case '[object Boolean]':
+			ty = 'Boolean';
+			break;
 	}
 	return ty;
+}
+
+exports.isEmpty = function(data) {
+	if (typeof(data) == 'number' || typeof(data) == 'boolean') {
+		return false;
+	}
+	if (typeof(data) == 'undefined' || data === null) {
+		return true;
+	}
+	if (typeof(data.length) != 'undefined') {
+		return data.length == 0;
+	}
+	var count = 0;
+	for (var i in data) {
+		if (data.hasOwnProperty(i)) {
+			count++;
+		}
+	}
+	return count == 0;
 }

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -1,0 +1,9 @@
+var assert = require('assert')
+
+module.exports = function(_, dir, finish, gm) {
+
+	assert.equal('append', gm.prototype.addMonitorCommand('append'));
+	assert.equal(false, gm.prototype.addMonitorCommand('777'));
+	finish();
+
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,10 +1,10 @@
 
 var assert = require('assert')
 
-module.exports = function (_, dir, finish, gm) {
+module.exports = function(_, dir, finish, gm) {
 
-  assert.equal('function', typeof gm.utils.escape);
-  assert.equal('function', typeof gm.utils.unescape);
-  finish();
+	assert.equal('function', typeof gm.utils.escape);
+	assert.equal('function', typeof gm.utils.unescape);
+	finish();
 
 }


### PR DESCRIPTION
Added basic feedback as per issue #239

Provide basic user feedback when using .monitor(): pipe raw io from spawned process (broker CLI output so it's visible) and wrap inside comments as rough command count for entire job.

TODO
-We cannot access progress information from binary, so best we can do (without string-fiddling - "*100%*" anyone?) is give a general idea of status / activity.
- Number of commands shown is not entirely accurate as switches are included (for now), which should not treated as part of the whole job. We could maintain a list of commands to include in args.js in future -this is a start.