### PR TITLE
Fixed: autoOrient strips profiles (#338) when using imagemagick

### DIFF
--- a/lib/convenience/autoOrient.js
+++ b/lib/convenience/autoOrient.js
@@ -25,7 +25,8 @@ module.exports = function (proto) {
     // nativeAutoOrient option enables this if you know you have >= 1.3.18
     if (this._options.nativeAutoOrient || this._options.imageMagick) {
       this.out('-auto-orient');
-      this.strip();
+      // only strip exif metadata when using graphicsmagick, imagemagick already removes the orientation tag
+      if (this._options.nativeAutoOrient) this.strip();
       return this;
     }
 


### PR DESCRIPTION
Removed striping all metadata when using native imagemagick -auto-orient, because it already removes the orientation-tag from the file. I guess graphicsmagick does not do that, so I kept the strip for that.