### PR TITLE
Add dispose support

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -211,6 +211,7 @@ module.exports = function (proto) {
       , self = this
       , proc, err
       , timeout = parseInt(this._options.timeout)
+      , disposers = this._options.disposers
       , timeoutId;
 
     debug(cmd);
@@ -228,13 +229,16 @@ module.exports = function (proto) {
 
     if (timeout) {
       timeoutId = setTimeout(function(){
-        err = new Error('gm() resulted in a timeout.');
-        cb(err);
-        if (proc.connected) {
-          proc.stdin.pause();
-          proc.kill();
-        }
+        dispose('gm() resulted in a timeout.');
       }, timeout);
+    }
+
+    if (disposers) {
+      disposers.forEach(function(disposer) {
+        disposer.events.forEach(function(event) {
+          disposer.emitter.on(event, dispose);
+        });
+      });
     }
 
     if (self.sourceBuffer) {
@@ -311,11 +315,21 @@ module.exports = function (proto) {
       if (cb.called) return;
       if (timeoutId) clearTimeout(timeoutId);
       cb.called = 1;
-			if (args[0] !== 'identify' && bin !== 'identify') {
-				self._in = [];
-				self._out = [];
-			}
+      if (args[0] !== 'identify' && bin !== 'identify') {
+	self._in = [];
+	self._out = [];
+      }
       callback.call(self, err, stdout, stderr, cmd);
+    }
+
+    function dispose (msg) {
+      var message = msg ? msg : 'gm() was disposed';
+      err = new Error(message);
+      cb(err);
+      if (proc.exitCode === null) {
+        proc.stdin.pause();
+        proc.kill();
+      }
     }
   }
 
@@ -408,4 +422,25 @@ module.exports = function (proto) {
 
     return rgx.test(this.source);
   }
+
+  /**
+   * add disposer (like 'close' of http.IncomingMessage) in order to dispose gm() with any event
+   *
+   * @param {EventEmitter} emitter
+   * @param {Array} events
+   * @return {Object} gm
+   * @example
+   *   command.addDisposer(req, ['close', 'end', 'finish']);
+   */
+
+  proto.addDisposer = function addDisposer (emitter, events) {
+    if (!this._options.disposers) {
+      this._options.disposers = [];
+    }
+    this._options.disposers.push({
+      emitter: emitter,
+      events: events
+    });
+    return this;
+  };
 }

--- a/test/dispose.js
+++ b/test/dispose.js
@@ -1,0 +1,45 @@
+var assert = require('assert');
+
+module.exports = function (img, dir, finish, gm) {
+  var EventEmitter = require('events').EventEmitter;
+  EventEmitter.prototype._maxListeners = 100;
+
+  assert.equal(undefined, gm.prototype._options.disposers);
+  assert.equal(undefined, img._options.disposers);
+
+  emitter = new EventEmitter();
+
+  disposer = {
+    emitter: emitter,
+    events: ['pleaseDispose', 'readyToDispose']
+  };
+
+  var g = gm('test').options({ disposers: [ disposer ] });
+  assert.deepEqual([disposer], g._options.disposers);
+
+  var sub = gm.subClass({ disposers: [ disposer ]});
+  assert.deepEqual([disposer], sub.prototype._options.disposers);
+
+  if (!gm.integration) {
+    return finish();
+  }
+
+  gm(dir + '/photo.JPG').options({ disposers: [ disposer ]})
+  .thumb(1000, 1000, dir + '/dispose.png', function (err) {
+    assert.ok(err, "Expecting a disposed error");
+  });
+
+  emitter.emit('pleaseDispose');
+
+  noDispose();
+
+  function noDispose() {
+    gm(dir + '/photo.JPG').options({ disposers: [ disposer ]})
+    .thumb(1000, 1000, dir + '/dispose.png', function (err) {
+      delete emitter;
+      delete disposer;
+      finish(err);
+    });
+    emitter.emit('disposeOK');
+  }
+}


### PR DESCRIPTION
This pull request adds a dispose option to the gm instance.
The disposer consists of an EventEmitter and events. We can add multiple disposers.
e.g.

```javascript
gm(dir + '/photo.JPG').options({
  disposers: [
    {
      emitter: emitter1,
      events: ['start']
    },
    {
      emitter: emitter2,
      events: ['end', 'error']
    }
  ]
});
```

or we can add after instanciation.
e.g

```javascript
gm.addDisposer(emitter3, ['close', 'aborted']);
```

after this PR, for example, we can dispose immediately when node connection is aborted or closed.

before:
![b29b418e-b2fc-11e5-9973-02eaa3cf08ea](https://cloud.githubusercontent.com/assets/537424/12140386/dbb72bf0-b4aa-11e5-813f-1fcb05582ae1.gif)
there are many convert processes after aborting requests.

after:
![cccdc5a4-b2fc-11e5-9c2d-7f94f23bb9dd](https://cloud.githubusercontent.com/assets/537424/12140401/fd473f58-b4aa-11e5-8ed9-bcf64cc9df0e.gif)
there are no convert processes left.

Best regards.