### PR TITLE
add decorate for drawText

### DIFF
--- a/lib/drawing.js
+++ b/lib/drawing.js
@@ -120,13 +120,19 @@ module.exports = function (proto) {
     , "south"
     , "southeast"];
 
-  // http://www.graphicsmagick.org/GraphicsMagick.html#details-draw
-  proto.drawText = function drawText (x0, y0, text, gravity) {
-    var gravity = String(gravity || "").toLowerCase()
-      , arg = ["text " + x0 + "," + y0 + " " + escape(text)];
+  proto._decorates = [
+    "underline",
+    "overline",
+    "line-through"];
 
-    if (~this._gravities.indexOf(gravity)) {
-      arg.unshift("gravity", gravity);
+  // http://www.graphicsmagick.org/GraphicsMagick.html#details-draw
+  proto.drawText = function drawText (x0, y0, text, gravity, decorate) {
+    var dec = decorate ? ("decorate " + (this._decorates.indexOf(decorate) > -1 ? decorate : this._decorates[0]) + " ") : "",
+        grav = String(gravity || "").toLowerCase(),
+        arg = [dec + "text " + x0 + "," + y0 + " " + escape(text)];
+
+    if (~this._gravities.indexOf(grav)) {
+      arg.unshift("gravity", grav);
     }
 
     return this.draw.apply(this, arg);


### PR DESCRIPTION
I added a variable 'decorate' for my task, it can be useful in the main repository?

http://www.graphicsmagick.org/api/types.html#drawcontext

decorate: none|underline|overline|line-through 
