### PR TITLE
Make thumbnail accept the same options as resize

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -589,8 +589,25 @@ module.exports = function (proto) {
   }
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-thumbnail
-  proto.thumbnail = function thumbnail (width, height) {
-    return this.out("-thumbnail", width + "x" + height);
+  proto.thumbnail = function thumbnail (w, h, options) {
+    options = options || "";
+    var geometry,
+      wIsValid = Boolean(w || w === 0),
+      hIsValid = Boolean(h || h === 0);
+
+    if (wIsValid && hIsValid) {
+      geometry = w + "x" + h + options
+    } else if (wIsValid) {
+      // GraphicsMagick requires <width>x<options>, ImageMagick requires <width><options>
+      geometry = (this._options.imageMagick) ? w + options : w +
+        'x' + options;
+    } else if (hIsValid) {
+      geometry = 'x' + h + options
+    } else {
+      return this
+    }
+
+    return this.out("-thumbnail", geometry);
   }
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-tile


### PR DESCRIPTION
I noticed `thumbnail()` didn't handle undefined args as well as `resize()`, they both accept the same options though.