### PR TITLE
Append warning from stderr to gm.identify 

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -137,6 +137,20 @@ module.exports = function (gm) {
         return;
       }
 
+      if (stderr.length > 0) {
+        var errors = stderr.split('\n').reduce(function (previous, current) {
+          var split = current.split('gm identify:');
+          if (split[1]) {
+            previous.push(split[1].trim());
+          }
+          return previous;
+        }, []);
+
+        if (errors.length) {
+          self.data.warning = errors;
+        }
+      }
+
       self.data.path = self.source;
 
       self.emit('identify', null, self.data);
@@ -343,4 +357,3 @@ module.exports = function (gm) {
     }
   };
 }
-


### PR DESCRIPTION
This can be used to detect file corruption warning from gm.