### PR TITLE
Use cross-spawn to spawn processes

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var utils = require('./utils');
 var debug = require('debug')('gm');
 var series = require('array-series');

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -1,6 +1,6 @@
 // compare
 
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 
 /**
  * Compare two images uses graphicsmagicks `compare` command.

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "async": "~0.9.0"
   },
   "dependencies": {
-    "debug": "~2.2.0",
+    "array-parallel": "~0.1.3",
     "array-series": "~0.1.5",
-    "array-parallel": "~0.1.3"
+    "cross-spawn": "^4.0.0",
+    "debug": "~2.2.0"
   }
 }


### PR DESCRIPTION
This provides better cross-platform support

For example, on Windows, I can now add [graphicsmagick-binary-win64](https://www.npmjs.com/package/graphicsmagick-binary-win64) as a dependency and then call `gm(path).options({ appPath: 'node_modules/.bin/', })` and use `gm` without having to make sure that GraphicsMagick is installed globally on whatever machine I'm using.

Thanks for your consideration!