### PR TITLE
works with webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,4 @@ require("./lib/montage")(gm.prototype);
 module.exports = exports = gm;
 module.exports.utils = require('./lib/utils');
 module.exports.compare = require('./lib/compare')();
-module.exports.version = JSON.parse(
-  require('fs').readFileSync(__dirname + '/package.json', 'utf8')
-).version;
-
+module.exports.version = require('./package.json').version;


### PR DESCRIPTION
Trying to read (__dirname + '/package.json') file at run-time won't work with
webpack. Using require('./package.json') instead allows webpack to include
package.json's source into the bundle.