### PR TITLE
Add method to force the input format

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function gm (source, height, color) {
   this._in = [];
   this._out = [];
   this._outputFormat = null;
+  this._inputFormat = null;
   this._subCommand = 'convert';
 
   if (source instanceof Stream) {
@@ -73,6 +74,10 @@ function gm (source, height, color) {
 
     var inputFromStdin = this.sourceStream || this.sourceBuffer;
     var ret = inputFromStdin ? '-' : this.source;
+
+    if (this._inputFormat) {
+      ret = this._inputFormat + ':' + ret;
+    }
 
     if (ret && this.sourceFrames) ret += this.sourceFrames;
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -721,6 +721,12 @@ module.exports = function (proto) {
     return this;
   }
 
+  // force input format
+  proto.setInputFormat = function setInputFormat (format) {
+    if (format) this._inputFormat = format;
+    return this;
+  }
+
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-resize
   proto.resize = function resize (w, h, options) {
     options = options || "";

--- a/test/setInputFormat.js
+++ b/test/setInputFormat.js
@@ -1,0 +1,24 @@
+
+var assert = require('assert')
+
+module.exports = function (gm, dir, finish, GM) {
+
+  var m = gm
+  .setInputFormat('jpeg');
+
+  assert.equal('jpeg', m._inputFormat);
+
+  assert.deepEqual(m.args(), [
+    'convert',
+    'jpeg:' + dir + '/original.jpg',
+    '-'
+  ]);
+
+  if (!GM.integration)
+    return finish();
+
+  m
+  .write(dir + '/setInputformat', function setInputformat (err) {
+    finish(err);
+  });
+}


### PR DESCRIPTION
This is useful for files comming from stdin and do not have magic bytes, such
as ICO files.