### PR TITLE
Use `magick` executable for ImageMagick on Windows

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -204,7 +204,7 @@ module.exports = function (proto) {
   proto._spawn = function _spawn (args, bufferOutput, callback) {
     var appPath = this._options.appPath || '';
     var bin = this._options.imageMagick
-      ? appPath + args.shift()
+      ? appPath + (process.platform === 'win32' ? 'magick' : args.shift())
       : appPath + 'gm'
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -23,10 +23,10 @@ module.exports = exports = function (proto) {
     var isImageMagick = this._options && this._options.imageMagick;
     var appPath = this._options && this._options.appPath || '';
     var bin = isImageMagick
-      ? appPath + 'compare' 
+      ? appPath + (process.platform === 'win32' ? 'magick' : 'compare')
       : appPath + 'gm'
     var args = ['-metric', 'mse', orig, compareTo]
-    if (!isImageMagick) {
+    if (!isImageMagick || process.platform === 'win32') {
         args.unshift('compare');
     }
     var tolerance = 0.4;


### PR DESCRIPTION
Because of name conflicts with some system executables, ImageMagick uses a single executable `magick` on the Windows platform. This commit reflects that, and makes it possible to use ImageMagick on Windows via the `gm` module again.

Fixes #559
