### PR TITLE
Enable error handling when streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,13 @@ gm(request(url))
 // (can be piped to a local file or remote server)
 gm('/path/to/my/img.jpg')
 .resize('200', '200')
-.stream(function (err, stdout, stderr) {
+.stream(function (err, stdout, stderr, cmd, proc) {
   var writeStream = fs.createWriteStream('/path/to/my/resized.jpg');
   stdout.pipe(writeStream);
+
+  proc.on('error', function (e) {
+    // Handle error.
+  });
 });
 
 // without a callback, .stream() returns a stream
@@ -170,7 +174,7 @@ gm('/path/to/my/img.jpg')
 // pass a format or filename to stream() and
 // gm will provide image data in that format
 gm('/path/to/my/img.jpg')
-.stream('png', function (err, stdout, stderr) {
+.stream('png', function (err, stdout, stderr, cmd, proc) {
   var writeStream = fs.createWriteStream('/path/to/my/reformatted.png');
   stdout.pipe(writeStream);
 });
@@ -185,7 +189,7 @@ gm('/path/to/my/img.jpg')
 var readStream = fs.createReadStream('/path/to/my/img.jpg');
 gm(readStream)
 .resize('200', '200')
-.stream(function (err, stdout, stderr) {
+.stream(function (err, stdout, stderr, cmd, proc) {
   var writeStream = fs.createWriteStream('/path/to/my/resized.jpg');
   stdout.pipe(writeStream);
 });

--- a/lib/command.js
+++ b/lib/command.js
@@ -79,7 +79,7 @@ module.exports = function (proto) {
    *
    * @param {String} name
    * @param {Function} callback
-   * @return {Object} gm
+   * @return {null}
    */
 
   proto.write = function write (name, callback) {
@@ -105,11 +105,14 @@ module.exports = function (proto) {
   /**
    * Execute the command and return stdin and stderr
    * ReadableStreams providing the image data.
+   * If a callback is passed, it is invoked immediately. To get process
+   * errors or the exit status, listen for the "error" event on the
+   * ChildProcess which is passed to the callback.
    * If no callback is passed, a "through" stream will be returned,
    * and stdout will be piped through, otherwise the error will be passed.
    *
    * @param {String} format (optional)
-   * @param {Function} callback (optional)
+   * @param {Function} callback (optional), signature (err, stdout, stderr, cmd, proc)
    * @return {Stream}
    */
 
@@ -123,9 +126,12 @@ module.exports = function (proto) {
 
     if ("function" !== typeof callback) {
       throughStream = new PassThrough();
-      callback = function (err, stdout, stderr) {
+      callback = function (err, stdout, stderr, cmd, proc) {
         if (err) throughStream.emit('error', err);
         else stdout.pipe(throughStream);
+        proc.on('error', function (err) {
+          throughStream.emit('error', err);
+        });
       }
     }
 
@@ -196,8 +202,8 @@ module.exports = function (proto) {
     * @param {Array} args
     * @param {ReadableStream} stream
     * @param {Boolean} shouldBuffer
-    * @param {Function} callback, signature (err, stdout, stderr) -> * 
-    * @return {Object} gm
+    * @param {Function} callback, signature (err, stdout, stderr, cmd, proc) -> *
+    * @return {null}
     * @TODO refactor this mess
     */
 
@@ -226,14 +232,6 @@ module.exports = function (proto) {
       return cb(e);
     }
     proc.stdin.once('error', cb);
-    
-    proc.on('error', function(err){
-      if (err.code === 'ENOENT') {
-        cb(new Error('Could not execute GraphicsMagick/ImageMagick: '+cmd+" this most likely means the gm/convert binaries can't be found"));
-      } else {
-        cb(err);
-      }
-    });
 
     if (timeout) {
       timeoutId = setTimeout(function(){
@@ -296,30 +294,38 @@ module.exports = function (proto) {
         stderr += data;
       });
 
+      proc.on('error', function(err){
+        if (err.code === 'ENOENT') {
+          cb(new Error('Could not execute GraphicsMagick/ImageMagick: '+cmd+" this most likely means the gm/convert binaries can't be found"));
+        } else {
+          cb(err);
+        }
+      });
+
       proc.on('close', onExit = function (code, signal) {
         if (code !== 0 || signal !== null) {
           err = new Error('Command failed: ' + stderr);
           err.code = code;
           err.signal = signal;
         };
-        cb(err, stdout, stderr, cmd);
+        cb(err, stdout, stderr);
         stdout = stderr = onOut = onErr = onExit = null;
       });
     } else {
-      cb(null, proc.stdout, proc.stderr, cmd);
+      cb(null, proc.stdout, proc.stderr);
     }
 
     return self;
 
-    function cb (err, stdout, stderr, cmd) {
+    function cb (err, stdout, stderr) {
       if (cb.called) return;
       if (timeoutId) clearTimeout(timeoutId);
       cb.called = 1;
       if (args[0] !== 'identify' && bin !== 'identify') {
-	self._in = [];
-	self._out = [];
+        self._in = [];
+        self._out = [];
       }
-      callback.call(self, err, stdout, stderr, cmd);
+      callback.call(self, err, stdout, stderr, cmd, proc);
     }
 
     function dispose (msg) {


### PR DESCRIPTION
See discussion of the problem in #256 (and a bit more in #548).

Adding `proc` to the `.stream()` callback seems like the easiest way to allow the caller to handle this. Tested in a downstream package and it works, though it's not terribly convenient.

When no callback is provided, emit an `error` event on the throughStream.

Before and after this change, I have two failing tests, which appear to be unrelated.