### PR TITLE
fix bug which results in images with wrong colors

### DIFF
--- a/lib/convenience/autoOrient.js
+++ b/lib/convenience/autoOrient.js
@@ -25,7 +25,7 @@ module.exports = function (proto) {
     // nativeAutoOrient option enables this if you know you have >= 1.3.18
     if (this._options.nativeAutoOrient || this._options.imageMagick) {
       this.out('-auto-orient');
-      this.strip();
+      // this.strip();
       return this;
     }
 
@@ -46,7 +46,7 @@ module.exports = function (proto) {
           this._out.unshift.apply(this._out, transforms.concat('-page', '+0+0'));
         }
 
-        this.strip();
+        // this.strip();
 
         callback();
       });


### PR DESCRIPTION
Strip removes the the color profile which results in wrong colors for images with AdobeRGB profile.
What's the reason to remove the color profile on auto orient?