### PR TITLE
Support programmatically several images sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ gm(200, 400, "#ddff99f3")
 .write("/path/to/brandNewImg.jpg", function (err) {
   // ...
 });
+
+// several source images to one file that allow pages (pdf, gif, tiff)
+gm(['/path/to/img1.jpg', '/path/to/img2.png'])
+.write("/path/to/pdfWithImagesInPages.pdf", function (err) {
+  // ...
+});
+
+// several source pdf pages to one file that allow pages even other pdf (pdf, gif, tiff)
+gm(['/path/to/file.pdf[0]', '/path/to/file.pdf[1]'])
+.write("/path/to/pdfWithSelectedPages.pdf", function (err) {
+  // ...
+});
 ```
 
 ## Streams

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ util.inherits(gm, EventEmitter);
 /**
  * Constructor.
  *
- * @param {String|Number} path - path to img source or ReadableStream or width of img to create
+ * @param {String|Number} path - path or array of paths to img source or ReadableStream or width of img to create
  * @param {Number} [height] - optional filename of ReadableStream or height of img to create
  * @param {String} [color] - optional hex background color of created img
  */
@@ -64,6 +64,13 @@ function gm (source, height, color) {
       this.sourceFrames = source.substr(frames.index, frames[0].length);
       source = source.substr(0, frames.index);
     }
+  }
+  
+  if (Array.isArray(source)) {
+    // then source is an array of paths
+    // this allow set programatically several sources 
+    this.in.apply(this, source); //ES6 this.in(...source);
+    source = undefined;
   }
 
   this.source = source;


### PR DESCRIPTION
In order to create a pdf with several pages from images (or other formats that allow pages), I need to use gm final command like this: "gm convert image01.jpg image02.jpg  -quality 100 test.pdf".

So I add a way to add several "sources" to the main "gm()" function the "source" parameter now can be an array of paths and this allows "programmatically" set several sources, ex. read folder tree and set the paths to "gm()".

This is possible to achieve with chaining ".in()" custom argument or with spread operator ex. ".in(...[])" but it is less practical.

I added two user cases more in README.md in "Basic Usage" section.

