### PR TITLE
Listen to stderr in toBuffer, so if the convert command fials we can …

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -36,13 +36,24 @@ module.exports = function (proto) {
     }
   }
   
-  function streamToUnemptyBuffer(stream, callback) {
+  function streamToUnemptyBuffer(stream, callback, errorstream) {
     var done = false
     var buffers = []
 
     stream.on('data', function (data) {
       buffers.push(data)
     })
+
+    if (errorstream) {
+        errorstream.on('data', function (error) {
+          if (error) {
+              debug('Error stream data: ' + error.toString());
+              done = true;
+              buffers = null;
+              callback(error.toString());
+          }
+        });
+    }
 
     stream.on('end', function () {
       var result, err;
@@ -159,10 +170,10 @@ module.exports = function (proto) {
       throw new Error('gm().toBuffer() expects a callback.');
     }
 
-    return this.stream(format, function (err, stdout) {
+    return this.stream(format, function (err, stdout, stderr) {
       if (err) return callback(err);
 
-      streamToUnemptyBuffer(stdout, callback);
+      streamToUnemptyBuffer(stdout, callback, stderr);
     })
   }
 


### PR DESCRIPTION
Listen to stderr, so that if an error happened when executing the convert command return the error, instead of Error: Stream yields empty buffer.