### PR TITLE
Added invert parameter to adjoin to allow +adjoin

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -24,8 +24,8 @@ module.exports = function (proto) {
   }
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-adjoin
-  proto.adjoin = function adjoin () {
-    return this.out("-adjoin");
+  proto.adjoin = function adjoin (invert) {
+    return this.out(invert ? "+adjoin" : "-adjoin");
   }
 
   // http://www.graphicsmagick.org/GraphicsMagick.html#details-affine


### PR DESCRIPTION
To allow breaking PDF files into multiple image files the +adjoin is required, since the existing argument .adjoin() only added -adjoin to the command line it was necessary to provide a parameter (invert, true/false) to allow the developer to specify .adjoin(true) and get +adjoin on the command line.