### PR TITLE
Fix ImageMagick 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or clone the repo:
 
 ## Use ImageMagick instead of gm
 
-Subclass `gm` to enable ImageMagick
+Subclass `gm` to enable ImageMagick 7- or 7+ with legacy utilities installed
 
 ```js
 var fs = require('fs')
@@ -38,6 +38,13 @@ var fs = require('fs')
 gm('/path/to/my/img.jpg')
 .resize(240, 240)
 ...
+```
+
+Subclass `gm` to enable ImageMagick 7+
+
+```
+var fs = require('fs')
+  , gm = require('gm').subClass({imageMagick: '7+'});
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ gm('/path/to/my/img.jpg')
 
 Subclass `gm` to enable ImageMagick 7+
 
-```
+```js
 var fs = require('fs')
   , gm = require('gm').subClass({imageMagick: '7+'});
+
+...
 ```
 
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -203,9 +203,28 @@ module.exports = function (proto) {
 
   proto._spawn = function _spawn (args, bufferOutput, callback) {
     var appPath = this._options.appPath || '';
-    var bin = this._options.imageMagick
-      ? appPath + args.shift()
-      : appPath + 'gm'
+    var bin
+
+    // Resolve executable
+    switch (this._options.imageMagick) {
+        // ImgeMagick < 7 or >= 7 with legacy utilities (convert)
+        case true:
+            bin = args.shift();
+            break;
+
+        // ImgeMagick >= 7
+        case '7+':
+            bin = 'magick'
+            break;
+
+        // GraphicsMagick
+        default:
+            bin = 'gm';
+            break;
+    }
+
+    // Prepend app path
+    bin = appPath + bin
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')
       , self = this

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -22,13 +22,26 @@ module.exports = exports = function (proto) {
 
     var isImageMagick = this._options && this._options.imageMagick;
     var appPath = this._options && this._options.appPath || '';
-    var bin = isImageMagick
-      ? appPath + 'compare' 
-      : appPath + 'gm'
-    var args = ['-metric', 'mse', orig, compareTo]
-    if (!isImageMagick) {
-        args.unshift('compare');
+
+    // Resove executable
+    var bin
+
+    switch (isImageMagick) {
+        case true:
+            bin = 'compare';
+            break;
+        case '7+':
+            bin = 'magick compare'
+            break;
+        default:
+            bin = 'gm compare'
+            break
     }
+
+    // Prepend app path
+    bin = appPath + bin
+
+    var args = ['-metric', 'mse', orig, compareTo]
     var tolerance = 0.4;
     // outputting the diff image
     if (typeof options === 'object') {


### PR DESCRIPTION
Add new option when using ImageMagick 7+:

```js
var fs = require('fs')
  , gm = require('gm').subClass({imageMagick: '7+'});
```

Closes #524, #528, #559, #652, #682 
Alternate version to #594

Tested on Windows

See ImageMagick > [version 7 Porting Guide](https://imagemagick.org/script/porting.php) > Command Changes:
> The "magick" command is the new primary command of the Shell API, replacing the old "convert" command. 