### PR TITLE
Use magick command when `imagemagick` flag is enabled

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -204,7 +204,7 @@ module.exports = function (proto) {
   proto._spawn = function _spawn (args, bufferOutput, callback) {
     var appPath = this._options.appPath || '';
     var bin = this._options.imageMagick
-      ? appPath + args.shift()
+      ? appPath + 'magick'
       : appPath + 'gm'
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')


### PR DESCRIPTION
`convert` command will conflict with Windows builtin command. So it is better to use `magick` instead of using subcommands directly.