### PR TITLE
Show error message if reading stream fails

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -161,7 +161,18 @@ module.exports = function (proto) {
     return this.stream(format, function (err, stdout) {
       if (err) return callback(err);
 
-      streamToUnemptyBuffer(stdout, callback);
+      streamToUnemptyBuffer(stdout, (err, buffer) => {
+        if (err) {
+          // if we have an error, we want to include stderr
+          const stdErrOutput = Buffer.from(stderr.read()).toString('utf8')
+          if (stdErrOutput) {
+            err.message += `\n${stdErrOutput}`
+          }
+          return callback(err);
+        }
+
+        callback(null, buffer);
+      })
     })
   }
 


### PR DESCRIPTION
It's difficult to debug some errors when the only error message is "Stream yields empty buffer".

This adds stderr to the error message to make it easier to see what's going on.

## Before:
```
Stream yields empty buffer
```

## After:
```
Error converting pdf to image Error: Stream yields empty buffer
gm convert: "gs" "-q" "-dBATCH" "-dSAFER" "-dMaxBitmap=50000000" "-dNOPAUSE" "-sDEVICE=pnmraw" "-dTextAlphaBits=4" "-dGraphicsAlphaBits=4" "-r200x200" "-sOutputFile=/tmp/gmKaF5ew" "--" "/tmp/gmh3XZfq" "-c" "quit" (child process quit due to signal 11).
gm convert: Request did not return an image.
```